### PR TITLE
Add include_stacktrace and include_screenshot params for testui_error()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,266 @@
-venv
-.tox
-*.egg-info
-allure*
-*.apk
-dist
-build
-.idea
+
+# Created by https://www.toptal.com/developers/gitignore/api/python,visualstudiocode,pycharm,macos
+# Edit at https://www.toptal.com/developers/gitignore?templates=python,visualstudiocode,pycharm,macos
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### PyCharm ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### PyCharm Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+# https://plugins.jetbrains.com/plugin/7973-sonarlint
+.idea/**/sonarlint/
+
+# SonarQube Plugin
+# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+.idea/**/sonarIssues.xml
+
+# Markdown Navigator plugin
+# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
+.idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator-enh.xml
+.idea/**/markdown-navigator/
+
+# Cache file creation bug
+# See https://youtrack.jetbrains.com/issue/JBR-2257
+.idea/$CACHE_FILE$
+
+# CodeStream plugin
+# https://plugins.jetbrains.com/plugin/12206-codestream
+.idea/codestream.xml
+
+### Python ###
+# Byte-compiled / optimized / DLL files
 __pycache__/
-appium_logs
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+pytestdebug.log
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
 *.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+doc/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#poetry.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+# .env
+.env/
+.venv/
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+pythonenv*
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# operating system-related files
+*.DS_Store #file properties cache/storage on macOS
+Thumbs.db #thumbnail cache on Windows
+
+# profiling data
+.prof
+
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/tasks.json
+!.vscode/launch.json
+*.code-workspace
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+### PyTestUI ###
+# Output
+report_cases.txt
+
+# End of https://www.toptal.com/developers/gitignore/api/python,visualstudiocode,pycharm,macos

--- a/tests/appium_tests.py
+++ b/tests/appium_tests.py
@@ -6,18 +6,24 @@ from testui.support.appium_driver import NewDriver
 from testui.support.testui_driver import TestUIDriver
 
 
-class TestStringMethods(object):
-    @pytest.yield_fixture(autouse=True)
-    def selenium_driver(self):
-        driver = NewDriver() \
-            .set_logger().set_chrome_driver().set_soft_assert(True).set_appium_driver()
-        yield driver
-        driver.quit()
+@pytest.yield_fixture(autouse=True)
+def driver() -> TestUIDriver:
+    driver = (
+        NewDriver()
+        .set_logger()
+        .set_chrome_driver()
+        .set_soft_assert(True)
+        .set_appium_driver()
+    )
 
-    @pytest.mark.signup
-    def test_sign_up_flow(self, selenium_driver: TestUIDriver):
-        logger.log_test_name("T92701: Create an account")
-        selenium_driver.navigate_to('https://google.com')
-        landing_page = LandingScreen(selenium_driver)
-        landing_page.i_am_in_mobile_landing_screen()
-        selenium_driver.raise_errors()
+    yield driver
+
+    driver.quit()
+
+@pytest.mark.signup
+def test_appium(driver: TestUIDriver):
+    logger.log_test_name("T92701: Create an account")
+    driver.navigate_to('https://google.com')
+    landing_page = LandingScreen(driver)
+    landing_page.i_am_in_mobile_landing_screen()
+    driver.raise_errors()

--- a/tests/selenium_tests.py
+++ b/tests/selenium_tests.py
@@ -1,6 +1,5 @@
-from time import sleep
-
 import pytest
+
 from selenium.webdriver.chrome.options import Options
 
 from tests.screens.landing import LandingScreen
@@ -9,21 +8,30 @@ from testui.support.appium_driver import NewDriver
 from testui.support.testui_driver import TestUIDriver
 
 
-class TestStringMethods(object):
-    @pytest.yield_fixture(autouse=True)
-    def selenium_driver(self):
-        options = Options()
-        options.add_argument("disable-user-media-security")
-        driver = NewDriver() \
-            .set_logger().set_browser('chrome').set_remote_url("http://localhost:4444/wd/hub").set_soft_assert(True) \
-            .set_selenium_driver(chrome_options=options)
-        yield driver
-        driver.quit()
+@pytest.fixture(autouse=True)
+def driver() -> TestUIDriver:
+    options = Options()
+    options.add_argument("disable-user-media-security")
+    
+    driver = (
+        NewDriver()
+        .set_logger()
+        .set_browser('chrome')
+        .set_remote_url("http://localhost:4444/wd/hub")
+        .set_soft_assert(True) 
+        .set_selenium_driver(chrome_options=options)
+    )
 
-    @pytest.mark.signup
-    def test_sign_up_flow(self, selenium_driver: TestUIDriver):
-        logger.log_test_name("T92701: Create an account")
-        selenium_driver.navigate_to('https://google.com')
-        landing_page = LandingScreen(selenium_driver)
-        landing_page.i_am_in_landing_screen()
-        selenium_driver.raise_errors()
+    yield driver
+    
+    driver.quit()
+
+@pytest.mark.signup
+def test_sign_up_flow(driver: TestUIDriver):
+    logger.log_test_name("T92701: Create an account")
+    
+    driver.navigate_to('https://google.com')
+    landing_page = LandingScreen(driver)
+    landing_page.i_am_in_landing_screen()
+    
+    driver.raise_errors()


### PR DESCRIPTION
ATM `testui_error()` in `testui.elements.testui_element` creates screenshot and includes full stacktrace for all errors but this behavior should be changeable. For this reason, function's signature has been updated to:
```py
def testui_error(
    driver: TestUIDriver,
    exception: str,
    include_stacktrace: bool = True,
    include_screenshot: bool = True
) -> None:
```

By default `include_stacktrace` and `include_screenshot` are `True` due to backward-compatibility but IMO it should be `False` since additional log verbosity usually is optional. This is up to maintainers to decide what is the default behavior 😉 

Also updated example tests to remove the unnecessary wrapping class and updated `.gitignore` to exclude files as per [this](https://www.toptal.com/developers/gitignore/api/python,visualstudiocode,pycharm,macos).