### PR TITLE
Add clear() command

### DIFF
--- a/testui/elements/testui_element.py
+++ b/testui/elements/testui_element.py
@@ -2,11 +2,14 @@ import time
 import os
 
 from os import path
+from typing import List
 
 from appium.webdriver.common.touch_action import TouchAction
+from appium.webdriver.webelement import WebElement
 from selenium.webdriver.common.by import By
 
 from testui.support import logger
+from testui.support.testui_driver import TestUIDriver
 from testui.support.helpers import error_with_traceback
 from testui.support.testui_images import Dimensions, ImageRecognition
 
@@ -70,7 +73,7 @@ class ElementException(Error):
 
 
 class Elements(object):
-    def __init__(self, driver, locator_type: str, locator: str):
+    def __init__(self, driver: TestUIDriver, locator_type: str, locator: str):
         self.logger = driver.logger_name
         self.__soft_assert = driver.soft_assert
         self.testui_driver = driver
@@ -98,7 +101,7 @@ class Elements(object):
         self.index = index
         return self
 
-    def get_element(self, index=0):
+    def get_element(self, index=0) -> WebElement:
         if self.__is_collection:
             return self.__find_by_collection()[self.index]
         elif index != 0:
@@ -106,7 +109,7 @@ class Elements(object):
         else:
             return self.__find_by_element()
 
-    def __find_by_element(self):
+    def __find_by_element(self) -> WebElement:
         if self.locator_type == "id":
             return self.driver.find_element_by_id(self.locator)
         if self.locator_type == "android_id_match":
@@ -130,7 +133,7 @@ class Elements(object):
         else:
             raise ElementException(f"locator not supported: {self.locator_type}")
 
-    def __find_by_collection(self):
+    def __find_by_collection(self) -> List[WebElement]:
         if self.locator_type == "id":
             return self.driver.find_elements_by_id(self.locator)
         if self.locator_type == "android_id_match":
@@ -608,6 +611,9 @@ class Elements(object):
             f'{logger.bcolors.FAIL}{err} {self.device_name}: Element not found with the following locator: '
             f'"{self.locator_type}:{self.locator}" after {time.time() - start}s {logger.bcolors.ENDC}'
         )
+    
+    def clear(self) -> None:
+        self.get_element().clear()
 
     def get_text(self):
         timeout = 10  # [seconds]

--- a/testui/elements/testui_element.py
+++ b/testui/elements/testui_element.py
@@ -9,7 +9,6 @@ from appium.webdriver.webelement import WebElement
 from selenium.webdriver.common.by import By
 
 from testui.support import logger
-from testui.support.testui_driver import TestUIDriver
 from testui.support.helpers import error_with_traceback
 from testui.support.testui_images import Dimensions, ImageRecognition
 
@@ -73,7 +72,7 @@ class ElementException(Error):
 
 
 class Elements(object):
-    def __init__(self, driver: TestUIDriver, locator_type: str, locator: str):
+    def __init__(self, driver, locator_type: str, locator: str):
         self.logger = driver.logger_name
         self.__soft_assert = driver.soft_assert
         self.testui_driver = driver

--- a/testui/support/appium_driver.py
+++ b/testui/support/appium_driver.py
@@ -7,6 +7,7 @@ from time import sleep
 
 from ppadb.client import Client as AdbClient
 from appium.webdriver import Remote
+from appium.webdriver.webdriver import WebDriver
 from selenium import webdriver
 from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
 from webdriver_manager import chrome
@@ -21,7 +22,7 @@ class NewDriver:
 
     def __init__(self):
         self.browser = False
-        self.__driver = None
+        self.__driver: WebDriver = None
         self.__app_path = None
         self.udid = None
         self.__appium_url = None
@@ -262,7 +263,7 @@ def start_driver(desired_caps, url, debug, port, udid, log_file):
     raise err
 
 
-def start_selenium_driver(desired_caps, url=None, debug=None, browser=None, chrome_options=None, firefox_options=None):
+def start_selenium_driver(desired_caps, url=None, debug=None, browser=None, chrome_options=None, firefox_options=None) -> WebDriver:
     options = chrome_options
     if firefox_options is not None:
         options = firefox_options

--- a/testui/support/testui_driver.py
+++ b/testui/support/testui_driver.py
@@ -6,6 +6,7 @@ from os import path
 from pathlib import Path
 
 from appium.webdriver.common.touch_action import TouchAction
+from appium.webdriver.webdriver import WebDriver
 from selenium.webdriver import TouchActions, ActionChains
 
 from testui.elements import testui_element
@@ -18,7 +19,7 @@ class TestUIDriver:
     __test__ = False
 
 
-    def __init__(self, driver):
+    def __init__(self, driver: 'TestUIDriver'):
         self.__soft_assert = driver.soft_assert
         self.__appium_driver = driver.get_driver()
         self.__process = driver.process
@@ -190,7 +191,7 @@ class TestUIDriver:
         root_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
         os.remove(root_dir + f'/testui-{image_name}')
 
-    def get_driver(self):
+    def get_driver(self) -> WebDriver:
         driver = self.__appium_driver
         return driver
 


### PR DESCRIPTION
Seems like `clear()` command was not implemented for Py-TestUI (also some missing type annotations were added)

This change was tested only on desktop Firefox using the following script
```py
from time import sleep
import time

import pytest
from selenium import webdriver
from selenium.webdriver.chrome.options import Options

from testui.support import logger
from testui.support.appium_driver import NewDriver
from testui.support.testui_driver import TestUIDriver
from testui.elements.testui_element import e


class TestStringMethods(object):
    @pytest.yield_fixture(autouse=True)
    def selenium_driver(self):
        options = Options()
        options.add_argument("disable-user-media-security")
        driver = NewDriver() \
            .set_logger().set_browser('firefox').set_soft_assert(True) \
            .set_selenium_driver()
        yield driver
        driver.quit()

    @pytest.mark.signup
    def test_sign_up_flow(self, selenium_driver: TestUIDriver):
        selenium_driver.navigate_to('https://duckduckgo.com/')
        e(selenium_driver, "css", "#search_form_input_homepage").wait_until_visible().send_keys("selenium")
        time.sleep(2)
        e(selenium_driver, "css", "#search_form_input_homepage").wait_until_visible().clear()
        time.sleep(2)
        selenium_driver.raise_errors()
```