### PR TITLE
Fix 0x9D in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The automation infrastructure implements the Page Object Model (POM) pattern. Th
             .
 ```
 
-The test case scripts are in a different class. The scripts import the respective screen package along with additional packages such as PyTest. Each class has any amount of tests. All test methods start with the word “test\_” such as:
+The test case scripts are in a different class. The scripts import the respective screen package along with additional packages such as PyTest. Each class has any amount of tests. All test methods start with the word "test\_" such as:
 
 ```py
     def test_add_existing_contact(self, appium_driver):
@@ -135,7 +135,7 @@ The test case scripts are in a different class. The scripts import the respectiv
 
 ### Element Locators Methods:
 
-The class “Elements” implements default locator methods that are part of the Appium WedDriver package. It adds additional functionality to wait for a configurable amount of time for an element to appear and provides improved error logging. It also implements methods for scrolling and swiping. Example of locators:
+The class "Elements" implements default locator methods that are part of the Appium WedDriver package. It adds additional functionality to wait for a configurable amount of time for an element to appear and provides improved error logging. It also implements methods for scrolling and swiping. Example of locators:
 
 ```py
     def e(driver, locator_type, locator):
@@ -219,7 +219,7 @@ Note: the image that you use for comparison can be a small portion of the screen
 
 ### Drivers:
 
-The testui_driver.py declares the TestUIDriver class which implements methods from the Elements class. It also implements methods such as “touch_actions” inherited from Selenium WebDriver TouchActions class.
+The testui_driver.py declares the TestUIDriver class which implements methods from the Elements class. It also implements methods such as "touch_actions" inherited from Selenium WebDriver TouchActions class.
 
 The appium_driver.py declares the NewDriver class which implements TestUIDriver. It also implements the desired capabilities such as the location of the .apk., the Chrome or iOS drivers, and others such as the Android version.
 
@@ -252,7 +252,7 @@ Chrome desktop browser:
         .set_selenium_driver()
 ```
 
-Before setting the driver you can choose among a different stacks of class methods to add different capabilities or functionality out-of-the-box from the framework such as “soft asserts“ or “log types“. Soft asserts make the automation run even when element assertions find errors, but in the end of said automation you can include the following line to rise the errors found:
+Before setting the driver you can choose among a different stacks of class methods to add different capabilities or functionality out-of-the-box from the framework such as "soft asserts" or "log types". Soft asserts make the automation run even when element assertions find errors, but in the end of said automation you can include the following line to rise the errors found:
 
 ```py
     driver = NewDriver() \


### PR DESCRIPTION
When trying to perform an installation by pip, I was hitting:

```
2021-08-30T09:23:32,633   Added git+https://github.com/jlennox/Py-TestUI@fix-readme to build tracker 'C:\\Users\\joe\\AppData\\Local\\Temp\\pip-req-tracker-n5n9v8oz'
2021-08-30T09:23:32,633     Running setup.py (path:C:\Users\joe\AppData\Local\Temp\pip-req-build-i0key725\setup.py) egg_info for package from git+https://github.com/jlennox/Py-TestUI@fix-readme
2021-08-30T09:23:32,633     Created temporary directory: C:\Users\joe\AppData\Local\Temp\pip-pip-egg-info-wd44y029
2021-08-30T09:23:32,633     Running command python setup.py egg_info
2021-08-30T09:23:32,766     Traceback (most recent call last):
2021-08-30T09:23:32,766       File "<string>", line 1, in <module>
2021-08-30T09:23:32,766       File "C:\Users\joe\AppData\Local\Temp\pip-req-build-i0key725\setup.py", line 4, in <module>
2021-08-30T09:23:32,766         long_description = fh.read()
2021-08-30T09:23:32,766       File "c:\users\joe\appdata\local\programs\python\python39\lib\encodings\cp1252.py", line 23, in decode
2021-08-30T09:23:32,766         return codecs.charmap_decode(input,self.errors,decoding_table)[0]
2021-08-30T09:23:32,766     UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 4369: character maps to <undefined>
```

I am not sure what makes it want to use `cp1252` vs another configuration -- I assume this is system dependent, but I believe the simplest/most universal fix would be to use simpler quote marks inside the readme.