### PR TITLE
fix element create method for testui driver

### DIFF
--- a/testui/support/testui_driver.py
+++ b/testui/support/testui_driver.py
@@ -56,7 +56,7 @@ class TestUIDriver:
         return self.__appium_driver.contexts
 
     def e(self, locator_type, locator):
-        return testui_element.e(self.__appium_driver, locator_type, locator)
+        return testui_element.e(self, locator_type, locator)
 
     def execute(self, driver_command, params=None):
         self.get_driver().execute(driver_command, params)


### PR DESCRIPTION
change create element - `TestUIDriver.e()` method to pass `self` not `__appium_driver`