### PR TITLE
fix full exception printing

### DIFF
--- a/testui/elements/testui_element.py
+++ b/testui/elements/testui_element.py
@@ -17,6 +17,7 @@ from testui.support.testui_images import Dimensions, ImageRecognition
 
 def testui_error(driver, exception: str) -> None:
     config = driver.configuration
+    exception += "\n"
 
     if config.save_screenshot_on_fail:
         try:
@@ -38,7 +39,7 @@ def testui_error(driver, exception: str) -> None:
         logger.log_error(full_exception)
         driver.set_error(full_exception)
         raise ElementException(
-            "There were errors during the UI testing, check the logs"
+            f'There were errors during the UI testing, check the logs:\n{full_exception}'
         )
 
 


### PR DESCRIPTION
The fix is rather simple, and it only adds the full stactraces to the exception handler. 

Also, I have added a jump line to the exception text, so that the trace is printed correctly