### PR TITLE
add 5 different python versions to test with

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,13 +14,16 @@ jobs:
   integration_test:
     runs-on: ubuntu-latest
     continue-on-error: true
+    strategy:
+      matrix:
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
 
     steps:
       - uses: actions/checkout@v3
-      - name: setup python
+      - name: setup python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
       - name: install requirements
         run: python -m pip install -r requirements.txt

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
 
     steps:
       - uses: actions/checkout@v3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # dev
-pylint==2.14.5
+pylint==3.0.2
 black==22.6.0
 build
 


### PR DESCRIPTION
right now the pipelines only test on the 3.10 version, but multiple users use from 3.8 to 3.12, so it would be nice to test those versions before merging