### PR TITLE
add deprecation notice for touch actions

### DIFF
--- a/testui/support/testui_driver.py
+++ b/testui/support/testui_driver.py
@@ -27,8 +27,11 @@ def deprecated(message):
                 stacklevel=2
             )
             return func(*args, **kwargs)
+
         return wrapper
+
     return decorator
+
 
 class TestUIDriver:
     """
@@ -226,12 +229,12 @@ class TestUIDriver:
         return self.driver.network_connection
 
     def find_image_match(
-        self,
-        comparison,
-        threshold=0.90,
-        assertion=False,
-        not_found=False,
-        image_match="",
+            self,
+            comparison,
+            threshold=0.90,
+            assertion=False,
+            not_found=False,
+            image_match="",
     ) -> bool:
         """
         Will find an image match based on the comparison type and threshold
@@ -490,13 +493,13 @@ class TestUIDriver:
         return self
 
     def stop_recording_and_compare(
-        self,
-        comparison,
-        threshold=0.9,
-        fps_reduction=1,
-        not_found=False,
-        keep_image_as="",
-        assertion=True,
+            self,
+            comparison,
+            threshold=0.9,
+            fps_reduction=1,
+            not_found=False,
+            keep_image_as="",
+            assertion=True,
     ) -> bool:
         """
         Stop recording the screen and compare the video with the given image

--- a/testui/support/testui_driver.py
+++ b/testui/support/testui_driver.py
@@ -1,5 +1,6 @@
 import base64
 import os
+import warnings
 
 from datetime import datetime
 from os import path
@@ -9,7 +10,6 @@ from appium.webdriver.common.touch_action import TouchAction
 from appium.webdriver.webdriver import WebDriver
 from selenium.webdriver import ActionChains
 from selenium.common.exceptions import WebDriverException
-from warnings import deprecated
 
 from testui.elements.testui_element import e
 from testui.support import logger
@@ -17,6 +17,18 @@ from testui.support.helpers import error_with_traceback
 from testui.support.testui_images import get_point_match, ImageRecognition
 from testui.support.configuration import Configuration
 
+
+def deprecated(message):
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            warnings.warn(
+                f"{func.__name__} is deprecated: {message}",
+                category=DeprecationWarning,
+                stacklevel=2
+            )
+            return func(*args, **kwargs)
+        return wrapper
+    return decorator
 
 class TestUIDriver:
     """
@@ -121,7 +133,7 @@ class TestUIDriver:
                 logger.log_debug("Log file already removed")
         return self
 
-    @deprecated("use actions() instead")
+    @deprecated("This method is deprecated and will be removed in a future version. Use actions() instead")
     def touch_actions(self) -> TouchAction:
         """
         Deprecated function, soon to be removed, use actions instead.

--- a/testui/support/testui_driver.py
+++ b/testui/support/testui_driver.py
@@ -9,6 +9,7 @@ from appium.webdriver.common.touch_action import TouchAction
 from appium.webdriver.webdriver import WebDriver
 from selenium.webdriver import ActionChains
 from selenium.common.exceptions import WebDriverException
+from warnings import deprecated
 
 from testui.elements.testui_element import e
 from testui.support import logger
@@ -120,6 +121,7 @@ class TestUIDriver:
                 logger.log_debug("Log file already removed")
         return self
 
+    @deprecated("use actions() instead")
     def touch_actions(self) -> TouchAction:
         """
         Deprecated function, soon to be removed, use actions instead.


### PR DESCRIPTION
TouchActions is being removed from Appium in the 4.0.0 version, so we will introduce this deprecation notice, and remove it in the 1.3.0 version of python-testui