### PR TITLE
Fix IDE warnings of return when error on soft assert

### DIFF
--- a/testui/elements/testui_element.py
+++ b/testui/elements/testui_element.py
@@ -99,6 +99,7 @@ class Elements:
         :param exception: exception
         """
         testui_error(self.testui_driver, exception)
+        return self
 
     def get(self, index):
         """


### PR DESCRIPTION
This fixes warnings generated by IDEs that element actions might return None in case of soft assert and later called with next actions.